### PR TITLE
made Content-Type and Accept header for POST requests configurable

### DIFF
--- a/src/slowhttptest.cc
+++ b/src/slowhttptest.cc
@@ -376,8 +376,8 @@ bool SlowHTTPTest::init(const char* url, const char* verb,
       struct tm * timeinfo;
       time(&rawtime);
       timeinfo = localtime(&rawtime);
-      strftime(csv_file_name, 22, "slow_%H%M%Y%m%d.csv", timeinfo);
-      strftime(html_file_name, 23, "slow_%H%M%Y%m%d.html", timeinfo);
+      strftime(csv_file_name, 29, "slow_%Y-%m-%d_%H-%M-%S.csv", timeinfo);
+      strftime(html_file_name, 30, "slow_%Y-%m-%d_%H-%M-%S.html", timeinfo);
     }
     csv_report_.append(csv_file_name);
     html_report_.append(html_file_name);

--- a/src/slowhttptest.cc
+++ b/src/slowhttptest.cc
@@ -93,9 +93,10 @@ static const char* user_agents[] = {
 };
 static const char referer[] = 
     "Referer: https://github.com/shekyan/slowhttptest/\r\n";
+static const char content_type_default[] = "Content-Type: application/x-www-form-urlencoded\r\n";
+static const char accept_default[] = "Accept: text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5\r\n"; 
 static const char post_request[] = "Connection: close\r\n"
-    "Content-Type: application/x-www-form-urlencoded\r\n"
-    "Accept: text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5\r\n\r\n"
+    "\r\n"
     "foo=bar";
 // per RFC 2616 section 4.2, header can be any US_ASCII character (0-127),
 // but we'll start with X-
@@ -210,7 +211,8 @@ const char* SlowHTTPTest::get_random_extra() {
 }
 
 bool SlowHTTPTest::init(const char* url, const char* verb,
-    const char* path, const char* proxy) {
+    const char* path, const char* proxy,
+    const char* content_type, const char* accept) {
   if(!change_fd_limits()) {
     slowlog(LOG_INFO, "error setting open file limits\n");
     
@@ -287,6 +289,23 @@ bool SlowHTTPTest::init(const char* url, const char* verb,
   } else if(eSlowRead == test_type_) {
     verb_.append("GET");
   }
+  // Content-type
+  if(content_type != 0 && strlen(content_type)) {
+    content_type_.append("Content-Type: ");
+    content_type_.append(content_type);
+    content_type_.append(crlf);
+  } else {
+    content_type_.append(content_type_default);
+  }
+  // Accept
+  if(accept != 0 && strlen(accept)) {
+    accept_.append("Accept: ");
+    accept_.append(accept);
+    accept_.append(crlf);
+  } else {
+    accept_.append(accept_default);
+  }
+
   // start building request
   request_.clear();
   request_.append(verb_);
@@ -327,6 +346,8 @@ bool SlowHTTPTest::init(const char* url, const char* verb,
     ss << content_length_;
     request_.append(ss.str());
     request_.append("\r\n");
+    request_.append(content_type_);
+    request_.append(accept_);
     request_.append(post_request);
   } else if(eRange == test_type_) {
     GenerateRangeHeader(range_start_, 1, range_limit_, &request_);

--- a/src/slowhttptest.h
+++ b/src/slowhttptest.h
@@ -76,7 +76,8 @@ class SlowHTTPTest {
   ~SlowHTTPTest();
 
   bool init(const char* url, const char* verb,
-    const char* path, const char* proxy);
+    const char* path, const char* proxy,
+    const char* content_type, const char* accept);
   void report_parameters();
   void report_status(bool to_csv);
   void report_csv();
@@ -99,6 +100,8 @@ class SlowHTTPTest {
   std::string random_extra_;
   std::string verb_;
   std::string user_agent_;
+  std::string content_type_;
+  std::string accept_;
   std::string csv_report_;
   std::string html_report_;
   Url base_uri_;

--- a/src/slowhttptestmain.cc
+++ b/src/slowhttptestmain.cc
@@ -71,6 +71,8 @@ static void usage() {
       "                   followup data per tick, e.g. -x 2 generates\n"
       "                   X-xx: xx for header or &xx=xx for body, where x\n"
       "                   is random character (32)\n"
+      "  -C content-type  value of Content-type header (application/x-www-form-urlencoded)\n"
+      "  -A accept        value of Accept header (text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5)\n"
       "\nProbe/Proxy options:\n\n"
       "  -d host:port     all traffic directed through HTTP proxy at host:port (off)\n"
       "  -e host:port     probe traffic directed through HTTP proxy at host:port (off)\n"
@@ -138,7 +140,9 @@ int main(int argc, char **argv) {
   char path[1024] = { 0 };
   char proxy[1024] = { 0 };
   char verb[16] = { 0 };
-  // default vaules
+  char content_type[1024] = { 0 };
+  char accept[1024] = { 0 };
+  // default values
   int conn_cnt            = 50;
   int content_length      = 4096;
   int duration            = 240;
@@ -159,11 +163,14 @@ int main(int argc, char **argv) {
   ProxyType proxy_type = slowhttptest::eNoProxy;
   long tmp;
   int o;
-  while((o = getopt(argc, argv, ":HBRXgha:b:c:d:e:i:k:l:n:o:p:r:s:t:u:v:w:x:y:z:")) != -1) {
+  while((o = getopt(argc, argv, ":HBRXghA:C:a:b:c:d:e:i:k:l:n:o:p:r:s:t:u:v:w:x:y:z:")) != -1) {
     switch (o) {
       case 'a':
         if(!parse_int(range_start, 65539))
           return -1;
+        break;
+      case 'A':
+        strncpy(accept, optarg, 1023);
         break;
       case 'b':
         if(!parse_int(range_limit, 524288))
@@ -176,6 +183,9 @@ int main(int argc, char **argv) {
         if(!parse_int(conn_cnt, 1024))
 #endif
           return -1;
+        break;
+      case 'C':
+        strncpy(content_type, optarg, 1023);
         break;
       case 'd':
         strncpy(proxy, optarg, 1023);
@@ -299,7 +309,7 @@ int main(int argc, char **argv) {
       type, need_stats, pipeline_factor, probe_interval,
       range_start, range_limit, read_interval, read_len,
       window_lower_limit, window_upper_limit, proxy_type, debug_level));
-  if(!slow_test->init(url, verb, path, proxy)) {
+  if(!slow_test->init(url, verb, path, proxy, content_type, accept)) {
     slowlog(LOG_FATAL, "%s: error setting up slow HTTP test\n", __FUNCTION__);
     return -1;
   } else if(!slow_test->run_test()) {


### PR DESCRIPTION
Hi,
I needed  to have the Content-Type to be something other than the default application/x-www-form-urlencoded so I made that configurable and while I was at it, did the same with Accept.

Cheers,
Axel