### PR TITLE
Fix libopenssl >= 1.1.0 detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,10 @@ AC_PROG_CC
 
 # Checks for libraries.
 # FIXME: Replace `main' with a function in `-lssl':
-AC_CHECK_LIB([ssl], [SSL_library_init], [], [AC_MSG_ERROR([OpenSSL-devel is missing])])
+AC_CHECK_LIB([ssl], [SSL_library_init], [], [
+  # Checks for OpenSSL >= 1.1.0
+  AC_CHECK_LIB([ssl], [OPENSSL_init_ssl], [], [AC_MSG_ERROR([OpenSSL-devel is missing])])
+])
 
 # Checks for header files.
 AC_HEADER_STDC


### PR DESCRIPTION
* SSL_library_init() function is deprecated in OpenSSL >= 1.1.0 by
  OPENSSL_init_ssl(), therefore, no SSL_library_init() symbol in
  OpenSSL >= 1.1.0, the detection failed.

  The build script should further checks for OPENSSL_init_ssl()
  if the SSL_library_init() was not detected in the first place.

  Despite the SSL_library_init() is still valid in the slowhttptest's
  code due to the openssl/ssl.h provides the macro as below

  #define SSL_library_init() OPENSSL_init_ssl(0, NULL)