### PR TITLE
Remove a typo in user_agents

### DIFF
--- a/src/slowhttptest.cc
+++ b/src/slowhttptest.cc
@@ -86,7 +86,7 @@ static const char* user_agents[] = {
     "AppleWebKit/533.21.1 (KHTML, like Gecko) Version/5.0.5 Safari/533.21.1",
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:5.0.1) "
     "msnbot-131-253-46-102.search.msn.com",
-    "User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko"
+    "Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko"
     "AppleWebKit/534.30 (KHTML, like Gecko) Chrome/12.0.742.122 Safari/534.30",
     "Opera/9.80 (Macintosh; Intel Mac OS X 10.7.0; U; Edition MacAppStore; en) "
     "Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/534.34 (KHTML,like Gecko) PhantomJS/1.9.0 (development) Safari/534.34",


### PR DESCRIPTION
Hi, I am using slowhttptest to test the concurrency of my web server. It helped me a lot. Thank you!

And I also noticed an access record like this:
```
HEAD / HTTP/1.1
Host: localhost:1234
User-Agent: User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like GeckoAppleWebKit/534.30 (KHTML, like Gecko) Chrome/12.0.742.122 Safari/534.30
Referer: https://github.com/shekyan/slowhttptest/
Range: bytes=0-,5-0,5-1,5-2,5-3,5-4,5-5,5-6,5-7,5-...(deleted)
Accept-Encoding: gzip
Connection: close
```
I just deleted a typo in user_agents. Please merge it if it's okay. Thanks.