### PR TITLE
Could not compile on macOS Sierra

### DIFF
--- a/configure
+++ b/configure
@@ -2857,6 +2857,9 @@ END
 fi
 
 
+LDFLAGS="$LDFLAGS -L/usr/local/opt/openssl/lib"
+CPPFLAGS="$CPPFLAGS -I/usr/local/opt/openssl/include"
+
 # Checks for programs.
 ac_ext=cpp
 ac_cpp='$CXXCPP $CPPFLAGS'

--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,9 @@ AC_CONFIG_SRCDIR([src/slowhttptest.cc])
 AC_CONFIG_HEADERS([config.h])
 AM_INIT_AUTOMAKE
 
+LDFLAGS="$LDFLAGS -L/usr/local/opt/openssl/lib"
+CPPFLAGS="$CPPFLAGS -I/usr/local/opt/openssl/include"
+
 # Checks for programs.
 AC_PROG_CXX
 AC_PROG_CC

--- a/man/Makefile.in
+++ b/man/Makefile.in
@@ -255,9 +255,9 @@ $(srcdir)/Makefile.in:  $(srcdir)/Makefile.am  $(am__configure_deps)
 	      exit 1;; \
 	  esac; \
 	done; \
-	echo ' cd $(top_srcdir) && $(AUTOMAKE) --gnu man/Makefile'; \
+	echo ' cd $(top_srcdir) && $(AUTOMAKE) --foreign man/Makefile'; \
 	$(am__cd) $(top_srcdir) && \
-	  $(AUTOMAKE) --gnu man/Makefile
+	  $(AUTOMAKE) --foreign man/Makefile
 Makefile: $(srcdir)/Makefile.in $(top_builddir)/config.status
 	@case '$?' in \
 	  *config.status*) \


### PR DESCRIPTION
updated configure.ac to explicitely locate openssl headers
installed by brew.