### PR TITLE
Fix building a container if never configured

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN apk add --no-cache build-base git openssl-dev
 RUN mkdir /slowhttptest
 WORKDIR /slowhttptest
 COPY . /slowhttptest
+RUN touch ./*
 RUN ./configure --prefix=/usr/local
 RUN make && make install
 ENTRYPOINT ["slowhttptest"]


### PR DESCRIPTION
Fixes `aclocal-1.15 not found` when build a container from sources
that were never configured. Touching m4 and others makes automake
think they are up to date.
/cc @jbrownsc 