### PR TITLE
Check that the argument passed to freeaddrinfo(3) is not NULL.

### DIFF
--- a/src/slowhttptest.cc
+++ b/src/slowhttptest.cc
@@ -152,7 +152,9 @@ SlowHTTPTest::SlowHTTPTest(int delay, int duration,
 }
 
 SlowHTTPTest::~SlowHTTPTest() {
-  freeaddrinfo(addr_);
+  if (addr_) {
+    freeaddrinfo(addr_);
+  }
 
   for(std::vector<StatsDumper*>::iterator i = dumpers_.begin();
        i != dumpers_.end(); ++i) {


### PR DESCRIPTION
freeaddrinfo(NULL) will crash on OpenBSD and NetBSD, and also on systems
using musl libc such as Alpine Linux.