### PR TITLE
Dockerfile improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
-FROM alpine:3.9
+FROM alpine:3.9 as builder
 
 RUN apk add --no-cache build-base git openssl-dev autoconf automake
-WORKDIR /slowhttptest
-COPY . /slowhttptest
-RUN ./configure --prefix=/usr/local
-RUN make && make install
+WORKDIR /build
+COPY . /build
+RUN ./configure && make
+
+
+FROM alpine:3.9
+RUN apk add --no-cache libstdc++
+COPY --from=builder /build/src/slowhttptest /usr/local/bin/
 ENTRYPOINT ["slowhttptest"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
 FROM alpine:3.9
 
-RUN apk add --no-cache build-base git openssl-dev
-RUN mkdir /slowhttptest
+RUN apk add --no-cache build-base git openssl-dev autoconf automake
 WORKDIR /slowhttptest
 COPY . /slowhttptest
-RUN touch ./*
 RUN ./configure --prefix=/usr/local
 RUN make && make install
 ENTRYPOINT ["slowhttptest"]


### PR DESCRIPTION
These commits fix the issues with autotools files being out of date and dramatically reduce the size of the final Docker image from 207 MB to 7.86 MB.