### PR TITLE
Travis-ci:added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ branches:
   only:
    - master
    - /^devel_.*$/
+   - ppc64le
 
 before_install:
   - if [ -n "$GCC_VERSION" ]; then export CXX="g++-${GCC_VERSION}" CC="gcc-${GCC_VERSION}"; fi
@@ -20,7 +21,11 @@ script:
 matrix:
   include:
     - compiler: gcc
+      arch: amd64
     - compiler: gcc
+      arch: ppc64le
+    - compiler: gcc
+      arch: amd64
       addons:
         apt:
           sources:
@@ -30,6 +35,27 @@ matrix:
             - g++-5
       env: GCC_VERSION=5
     - compiler: gcc
+      arch: ppc64le
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-5
+            - g++-5
+      env: GCC_VERSION=5
+    - compiler: gcc
+      arch: amd64
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-6
+            - g++-6
+      env: GCC_VERSION=6
+    - compiler: gcc
+      arch: ppc64le
       addons:
         apt:
           sources:


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch on behalf of IBM. The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/slowhttptest/builds/208835448 . I believe it is ready for the final review and merge.
Please have a look on it.

Thanks !!