### PR TITLE
support mtls

### DIFF
--- a/man/slowhttptest.1
+++ b/man/slowhttptest.1
@@ -133,6 +133,14 @@ Specifies the end of the range the TCP advertised window size would be picked fr
 .It Fl z Ar bytes
 Specifies the number of bytes to read from receive buffer with each read() operation.
 .El
+.Sh ENVIRONMENT
+.Pp
+.Bl -tag -width Ds
+.It Ev SSL_CERT
+Specifies client certificate (PEM format)
+.It Ev SSL_KEY
+Specifies client private key (PEM format) 
+.El
 .Sh EXAMPLES
 Start a slowloris test of host.example.com with 1000 connections, statistics goes into my_header_stats,
 interval between follow up headers is 10 seconds and connection rate is 200 connections per second:

--- a/src/slowhttptestmain.cc
+++ b/src/slowhttptestmain.cc
@@ -95,6 +95,9 @@ static void usage() {
       "  -w bytes        start of the range advertised window size would be picked from (1)\n"
       "  -y bytes        end of the range advertised window size would be picked from (512)\n"
       "  -z bytes        bytes to slow read from receive buffer with single read() call (5)\n"
+      "\nEnvironment variables:\n\n"
+      "  SSL_CERT         client certificate (PEM format)\n"
+      "  SSL_KEY          client private key (PEM format)\n"
       );
 }
 

--- a/src/slowsocket.cc
+++ b/src/slowsocket.cc
@@ -165,6 +165,18 @@ bool SlowSocket::connect_ssl(addrinfo* addr, const char* sni) {
     close();
     return false;
   }
+  if (getenv("SSL_CERT") && getenv("SSL_KEY")) {
+    if(SSL_CTX_use_certificate_file(ssl_ctx_, getenv("SSL_CERT"), SSL_FILETYPE_PEM) <= 0) {
+      slowlog(LOG_ERROR, "cannot use client certificate\n");
+      close();
+      return false;
+    }
+    if(SSL_CTX_use_PrivateKey_file(ssl_ctx_, getenv("SSL_KEY"), SSL_FILETYPE_PEM) <= 0) {
+      slowlog(LOG_ERROR, "cannot use client private key\n");
+      close();
+      return false;
+    }
+  }
   ssl_ = SSL_new(ssl_ctx_);
   if(!ssl_) {
     SSL_CTX_free(ssl_ctx_);


### PR DESCRIPTION
Currently the tool does not support servers that require client certificate present. The tool stops with an error `Exit status: Connection refused`. I've added a possibility to specify client certificate and client key to handle such situations. Cert and keys are  set via environment variable because all single character parameter names are taken and I couldn't find an elegant way to handle multi-character parameter names.

PoC:
Step 1. Generate server and client self-signed certificates
```
openssl req -new -newkey rsa:2048 -days 365 -nodes -x509 -keyout server-key.pem -out server-cert.pem
openssl req -new -newkey rsa:2048 -days 365 -nodes -x509 -keyout client-key.pem -out client-cert.pem
```

Step 2. Run https server requiring mtls
```
openssl s_server -key server-key.pem -cert server-cert.pem -accept 4443 -Verify 1 -CAfile client-cert.pem -www -tls1_2
```

Step 3. Run the tool without cert/key pair. The tool stops to work.
```
./slowhttptest -X -u https://127.0.0.1:4443

Mon Aug 28 19:39:29 2023:
	slowhttptest version 1.9.0
 - https://github.com/shekyan/slowhttptest -
test type:                       SLOW READ
number of connections:           50
URL:                             https://127.0.0.1:4443/
verb:                            GET
cookie:                           
receive window range:            1 - 512
pipeline factor:                 1
read rate from receive buffer:   5 bytes / 1 sec
connections per seconds:         50
probe connection timeout:        5 seconds
test duration:                   240 seconds
using proxy:                     no proxy 

Mon Aug 28 19:39:29 2023:
slow HTTP test status on 0th second:

initializing:        0
pending:             1
connected:           0
error:               0
closed:              0
service available:   YES
Mon Aug 28 19:39:30 2023:
Test ended on 1th second
Exit status: Connection refused
```

Step 4. Run the tool with cert/key pair. The tool continues to work and successfully conducts the attack.
```
SSL_CERT=/home/mmm//slowhttptest/client-cert.pem SSL_KEY=/home/mmm/slowhttptest/client-key.pem ./slowhttptest -X -u https://127.0.0.1:4443

Mon Aug 28 19:40:34 2023:
	slowhttptest version 1.9.0
 - https://github.com/shekyan/slowhttptest -
test type:                       SLOW READ
number of connections:           50
URL:                             https://127.0.0.1:4443/
verb:                            GET
cookie:                           
receive window range:            1 - 512
pipeline factor:                 1
read rate from receive buffer:   5 bytes / 1 sec
connections per seconds:         50
probe connection timeout:        5 seconds
test duration:                   240 seconds
using proxy:                     no proxy 

Mon Aug 28 19:40:34 2023:
slow HTTP test status on 10th second:

initializing:        0
pending:             49
connected:           1
error:               0
closed:              0
service available:   NO
```